### PR TITLE
refactor: Status 타입 변경 String -> Enum

### DIFF
--- a/hibuy-server/src/main/java/hibuy/server/domain/BoolTake.java
+++ b/hibuy-server/src/main/java/hibuy/server/domain/BoolTake.java
@@ -2,17 +2,9 @@ package hibuy.server.domain;
 
 import static jakarta.persistence.FetchType.*;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
+
 import java.sql.Timestamp;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
@@ -32,7 +24,8 @@ public class BoolTake {
 
     private Timestamp takeDateTime;
 
-    private String status;
+    @Enumerated(EnumType.STRING)
+    private Status status;
 
     @CreatedDate
     @Column(name = "created_at", nullable = false, updatable = false)
@@ -46,13 +39,13 @@ public class BoolTake {
     @JoinColumn(name = "up_id")
     private UserProduct userProduct;
 
-    public BoolTake(Timestamp takeDateTime, String status, UserProduct userProduct) {
+    public BoolTake(Timestamp takeDateTime, Status status, UserProduct userProduct) {
         this.takeDateTime = takeDateTime;
         this.status = status;
         this.userProduct = userProduct;
     }
 
-    public void updateBoolTake(String status) {
+    public void updateBoolTake(Status status) {
         this.status = status;
     }
 }

--- a/hibuy-server/src/main/java/hibuy/server/domain/DailyTake.java
+++ b/hibuy-server/src/main/java/hibuy/server/domain/DailyTake.java
@@ -24,7 +24,8 @@ public class DailyTake {
     @Column(name = "take_date", nullable = false)
     private Date takeDate;
 
-    private String status;
+    @Enumerated(EnumType.STRING)
+    private Status status;
 
     @CreatedDate
     @Column(name = "created_at", nullable = false, updatable = false)
@@ -40,7 +41,7 @@ public class DailyTake {
 
     public DailyTake(Date takeDate, User user) {
         this.takeDate = takeDate;
-        this.status = "ACTIVE";
+        this.status = Status.ACTIVE;
         this.user = user;
     }
 }

--- a/hibuy-server/src/main/java/hibuy/server/domain/Product.java
+++ b/hibuy-server/src/main/java/hibuy/server/domain/Product.java
@@ -42,8 +42,8 @@ public class Product {
     @Column(nullable = false)
     private String category;
 
-    @Column
-    private String status;
+    @Enumerated(EnumType.STRING)
+    private Status status;
 
     @CreatedDate
     @Column(name = "created_at", updatable = false)
@@ -60,7 +60,7 @@ public class Product {
         this.imageUrl = imageUrl;
         this.productUrl = productUrl;
         this.category = category;
-        this.status = "ACTIVE";
+        this.status = Status.ACTIVE;
     }
 
 }

--- a/hibuy-server/src/main/java/hibuy/server/domain/Sample.java
+++ b/hibuy-server/src/main/java/hibuy/server/domain/Sample.java
@@ -33,8 +33,8 @@ public class Sample {
     @Column(name = "product_url")
     private String productUrl;
 
-    @Column
-    private String status;
+    @Enumerated(EnumType.STRING)
+    private Status status;
 
     @CreatedDate
     @Column(name = "created_at", updatable = false)
@@ -49,7 +49,7 @@ public class Sample {
         this.companyName = companyName;
         this.imageUrl = imageUrl;
         this.productUrl = productUrl;
-        this.status = "ACTIVE";
+        this.status = Status.ACTIVE;
     }
 
 }

--- a/hibuy-server/src/main/java/hibuy/server/domain/Status.java
+++ b/hibuy-server/src/main/java/hibuy/server/domain/Status.java
@@ -1,0 +1,5 @@
+package hibuy.server.domain;
+
+public enum Status {
+    ACTIVE, INACTIVE
+}

--- a/hibuy-server/src/main/java/hibuy/server/domain/User.java
+++ b/hibuy-server/src/main/java/hibuy/server/domain/User.java
@@ -29,8 +29,8 @@ public class User {
     @Column(name = "phone_number", nullable = false)
     private String phoneNumber;
 
-    @Column()
-    private String status;
+    @Enumerated(EnumType.STRING)
+    private Status status;
 
     @CreatedDate
     @Column(name = "created_at", updatable = false)
@@ -44,6 +44,6 @@ public class User {
         this.name = name;
         this.email = email;
         this.phoneNumber = phoneNumber;
-        this.status = "ACTIVE";
+        this.status = Status.ACTIVE;
     }
 }

--- a/hibuy-server/src/main/java/hibuy/server/domain/UserProduct.java
+++ b/hibuy-server/src/main/java/hibuy/server/domain/UserProduct.java
@@ -2,14 +2,7 @@ package hibuy.server.domain;
 
 import static jakarta.persistence.FetchType.*;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import java.sql.Timestamp;
 import lombok.AccessLevel;
@@ -38,7 +31,8 @@ public class UserProduct {
 
     private int takeCount;
 
-    private String status;
+    @Enumerated(EnumType.STRING)
+    private Status status;
 
     @CreatedDate
     @Column(updatable = false)
@@ -63,7 +57,7 @@ public class UserProduct {
         this.totalAmount = totalAmount;
         this.notification = notification;
         this.takeCount = 0;
-        this.status = "ACTIVE";
+        this.status = Status.ACTIVE;
         this.user = user;
         this.product = product;
     }

--- a/hibuy-server/src/main/java/hibuy/server/dto/booltake/PatchBoolTakeRequest.java
+++ b/hibuy-server/src/main/java/hibuy/server/dto/booltake/PatchBoolTakeRequest.java
@@ -2,6 +2,8 @@ package hibuy.server.dto.booltake;
 
 import java.sql.Date;
 import java.sql.Time;
+
+import hibuy.server.domain.Status;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -12,5 +14,6 @@ public class PatchBoolTakeRequest {
     private Long userProductId;
     private Date takeDate;
     private Time takeTime;
-    private String status;
+    private Status status;
+
 }

--- a/hibuy-server/src/main/java/hibuy/server/dto/userProduct/TakeStatusDto.java
+++ b/hibuy-server/src/main/java/hibuy/server/dto/userProduct/TakeStatusDto.java
@@ -1,6 +1,8 @@
 package hibuy.server.dto.userProduct;
 
 import java.sql.Time;
+
+import hibuy.server.domain.Status;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -9,5 +11,5 @@ import lombok.Getter;
 public class TakeStatusDto {
 
     private Time takeTime;
-    private String status;
+    private Status status;
 }

--- a/hibuy-server/src/main/java/hibuy/server/service/UserProductService.java
+++ b/hibuy-server/src/main/java/hibuy/server/service/UserProductService.java
@@ -1,11 +1,6 @@
 package hibuy.server.service;
 
-import hibuy.server.domain.BoolTake;
-import hibuy.server.domain.Product;
-import hibuy.server.domain.User;
-import hibuy.server.domain.UserProduct;
-import hibuy.server.domain.UserProductDay;
-import hibuy.server.domain.UserProductTime;
+import hibuy.server.domain.*;
 import hibuy.server.dto.userProduct.DailyUserProductDto;
 import hibuy.server.dto.userProduct.DeleteUserProductResponse;
 import hibuy.server.dto.userProduct.GetHomeUserProductsRequest;
@@ -92,7 +87,7 @@ public class UserProductService {
                 //날짜와 시간 결합
                 Timestamp takeTime = Timestamp.valueOf(LocalDateTime.of(localDate,
                         userProductTime.getTakeTime().toLocalTime()));
-                String status = "INACTIVE";
+                Status status = Status.ACTIVE;
 
                 BoolTake isTake = Optional.ofNullable(timestampBoolTakeMap.get(userProductId))
                         .map(inMap -> inMap.get(takeTime))


### PR DESCRIPTION
## 📝Issue: Status 타입 변경

## 📝Description
- Status의 타입을 String으로 사용하지 않고 enum 클래스를 따로 만들어서 active, inactive만 빼서 사용할 수 있도록 하였습니다.

## 📝Todo
- 도메인 중에 status가 존재하지 않는 도메인들이 존재 (ERD Cloud에도 동일) -> 의도가 아니라면 추후에 추가