### PR TITLE
Refactor: 환경 변수 주입 방식 변경 (Config 파일 분리)

### DIFF
--- a/src/main/java/hibuy/server/ServerApplication.java
+++ b/src/main/java/hibuy/server/ServerApplication.java
@@ -4,7 +4,6 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@EnableJpaAuditing
 @SpringBootApplication
 public class ServerApplication {
 

--- a/src/main/java/hibuy/server/common/config/JpaAuditingConfig.java
+++ b/src/main/java/hibuy/server/common/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package hibuy.server.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/src/main/java/hibuy/server/common/config/PropertiesConfiguration.java
+++ b/src/main/java/hibuy/server/common/config/PropertiesConfiguration.java
@@ -1,0 +1,10 @@
+package hibuy.server.common.config;
+
+import hibuy.server.common.config.properties.KakaoProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(value = {KakaoProperties.class})
+public class PropertiesConfiguration {
+}

--- a/src/main/java/hibuy/server/common/config/properties/KakaoProperties.java
+++ b/src/main/java/hibuy/server/common/config/properties/KakaoProperties.java
@@ -1,0 +1,18 @@
+package hibuy.server.common.config.properties;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@RequiredArgsConstructor
+@ConfigurationProperties(prefix = "kakao")
+public class KakaoProperties {
+
+    private final Oauth2 oauth2;
+
+    public record Oauth2(String redirectUri, String clientId, String clientSecret) {
+
+    }
+
+}

--- a/src/main/java/hibuy/server/controller/LoginController.java
+++ b/src/main/java/hibuy/server/controller/LoginController.java
@@ -19,9 +19,6 @@ public class LoginController {
 
     private final KakaoService kakaoService;
 
-    @Value("${kakao.oauth2.client_id}") private String clientId;
-    @Value("${kakao.oauth2.redirect_uri}") private String redirectUri;
-
     @GetMapping("/oauth2/code/kakao")
     public BaseResponse<LoginResponse> requestKakaoLogin(@RequestParam String code) {
 

--- a/src/main/java/hibuy/server/domain/DailyTake.java
+++ b/src/main/java/hibuy/server/domain/DailyTake.java
@@ -26,9 +26,9 @@ public class DailyTake extends BaseEntity{
     private User user;
 
     public DailyTake(Date takeDate, User user) {
+        super();
         this.takeDate = takeDate;
         this.user = user;
-        this.status = Status.ACTIVE;
     }
 
     public boolean isStatusInactive() {

--- a/src/main/java/hibuy/server/domain/User.java
+++ b/src/main/java/hibuy/server/domain/User.java
@@ -2,6 +2,7 @@ package hibuy.server.domain;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -27,11 +28,12 @@ public class User extends BaseEntity{
     @Column(name = "phone_number", nullable = false)
     private String phoneNumber;
 
-    public User(Long kakaoUserId, String name, String email, String phoneNumber) {
+    @Builder
+    private User(Long kakaoUserId, String name, String email, String phoneNumber) {
+        super();
         this.kakaoUserId = kakaoUserId;
         this.name = name;
         this.email = email;
         this.phoneNumber = phoneNumber;
-        this.status = Status.ACTIVE;
     }
 }

--- a/src/main/java/hibuy/server/dto/oauth2/KakaoUserInfoResponse.java
+++ b/src/main/java/hibuy/server/dto/oauth2/KakaoUserInfoResponse.java
@@ -1,10 +1,11 @@
 package hibuy.server.dto.oauth2;
 
+import hibuy.server.domain.User;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
 public class KakaoUserInfoResponse {
 
     private Long id;
@@ -17,16 +18,13 @@ public class KakaoUserInfoResponse {
         private String phone_number;
     }
 
-    public String getUsername() {
-        return this.getKakao_account().getName();
-    }
-
-    public String getUserEmail() {
-        return this.getKakao_account().getEmail();
-    }
-
-    public String getUserPhoneNumber() {
-        return this.getKakao_account().getPhone_number();
+    public User toEntity() {
+        return User.builder()
+                .kakaoUserId(id)
+                .name(kakao_account.name)
+                .email(kakao_account.email)
+                .phoneNumber(kakao_account.phone_number)
+                .build();
     }
 
 }

--- a/src/main/java/hibuy/server/repository/DailyTakeRepository.java
+++ b/src/main/java/hibuy/server/repository/DailyTakeRepository.java
@@ -1,12 +1,10 @@
 package hibuy.server.repository;
 
 import hibuy.server.domain.DailyTake;
-import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import javax.swing.text.html.Option;
 import java.sql.Date;
 import java.util.List;
 import java.util.Optional;
@@ -18,5 +16,5 @@ public interface DailyTakeRepository extends JpaRepository<DailyTake, Long> {
 
     @Query("SELECT dt FROM DailyTake dt JOIN dt.user u " +
             "WHERE u.userId = :userId AND u.status = 'ACTIVE' AND dt.takeDate = :takeDate")
-    Optional<DailyTake> findTakeDatesByUserIdAAndTakeDate(@Param("userId") Long userId, @Param("takeDate") Date takeDate);
+    Optional<DailyTake> findDailyTakeByUserIdAAndTakeDate(@Param("userId") Long userId, @Param("takeDate") Date takeDate);
 }

--- a/src/main/java/hibuy/server/repository/UserRepository.java
+++ b/src/main/java/hibuy/server/repository/UserRepository.java
@@ -2,14 +2,11 @@ package hibuy.server.repository;
 
 import hibuy.server.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
-    @Query("SELECT u FROM User u WHERE u.kakaoUserId = :kakaoUserId")
-    Optional<User> findByKakaoUserId(@Param("kakaoUserId") Long kakaoUserId);
+    Optional<User> findByKakaoUserId(Long kakaoUserId);
 
 }

--- a/src/main/java/hibuy/server/service/DailyTakeService.java
+++ b/src/main/java/hibuy/server/service/DailyTakeService.java
@@ -42,7 +42,7 @@ public class DailyTakeService {
         User user = userRepository.findById(userId)
                 .orElseThrow(NotFoundUserException::new);
 
-        Optional<DailyTake> dailyTakeOptional = dailyTakeRepository.findTakeDatesByUserIdAAndTakeDate(userId, date);
+        Optional<DailyTake> dailyTakeOptional = dailyTakeRepository.findDailyTakeByUserIdAAndTakeDate(userId, date);
 
         if(dailyTakeOptional.isEmpty()) {
             dailyTakeRepository.save(new DailyTake(date, user));

--- a/src/main/java/hibuy/server/service/KakaoService.java
+++ b/src/main/java/hibuy/server/service/KakaoService.java
@@ -1,5 +1,6 @@
 package hibuy.server.service;
 
+import hibuy.server.common.config.properties.KakaoProperties;
 import hibuy.server.common.http.RequestBody;
 import hibuy.server.domain.DateCount;
 import hibuy.server.domain.User;
@@ -29,13 +30,7 @@ public class KakaoService {
 
     private final UserRepository userRepository;
     private final DateCountRepository dateCountRepository;
-
-    @Value("${kakao.oauth2.client_id}")
-    private String clientId;
-    @Value("${kakao.oauth2.redirect_uri}")
-    private String redirectUri;
-    @Value("${kakao.oauth2.client_secret}")
-    private String clientSecret;
+    private final KakaoProperties kakaoProperties;
 
     public String getAccessToken(String code) {
 
@@ -95,19 +90,15 @@ public class KakaoService {
     private MultiValueMap<String, String> buildAccessTokenRequestBody(String code) {
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
         params.add(GRANT_TYPE.getName(), AUTHORIZATION_CODE.getName());
-        params.add(CLIENT_ID.getName(), clientId);
-        params.add(CLIENT_SECRET.getName(), clientSecret);
-        params.add(REDIRECT_URI.getName(), redirectUri);
+        params.add(CLIENT_ID.getName(), kakaoProperties.getOauth2().clientId());
+        params.add(CLIENT_SECRET.getName(), kakaoProperties.getOauth2().clientSecret());
+        params.add(REDIRECT_URI.getName(), kakaoProperties.getOauth2().redirectUri());
         params.add(CODE.getName(), code);
         return params;
     }
 
     private Long saveUserAndDateCount(KakaoUserInfoResponse kakaoUserInfoResponse) {
-        User savedUser = userRepository.save(new User(
-                kakaoUserInfoResponse.getId(),
-                kakaoUserInfoResponse.getUsername(),
-                kakaoUserInfoResponse.getUserEmail(),
-                kakaoUserInfoResponse.getUserPhoneNumber()));
+        User savedUser = userRepository.save(kakaoUserInfoResponse.toEntity());
 
         dateCountRepository.save(new DateCount(savedUser));
         return savedUser.getUserId();

--- a/src/test/java/hibuy/server/service/AddressServiceTest.java
+++ b/src/test/java/hibuy/server/service/AddressServiceTest.java
@@ -28,8 +28,6 @@ class AddressServiceTest {
     AddressRepository addressRepository;
     @Autowired
     AddressService addressService;
-    @MockBean KakaoService kakaoService;
-    @MockBean LoginController loginController;
 
     private User user;
     private Address address;
@@ -37,7 +35,12 @@ class AddressServiceTest {
 
     @BeforeEach
     void setUp() {
-        user = new User(1L, "jangwoo", "jangwoopark@naver.com", "01012345678");
+        user = User.builder()
+                .kakaoUserId(1L)
+                .name("jangwoo")
+                .email("jangwoopark@naver.com")
+                .phoneNumber("01012345678")
+                .build();
         userRepository.save(user);
 
         address = createAddress("장우네 집", true);

--- a/src/test/java/hibuy/server/service/BoolTakeServiceTest.java
+++ b/src/test/java/hibuy/server/service/BoolTakeServiceTest.java
@@ -47,11 +47,6 @@ class BoolTakeServiceTest {
     @Autowired
     BoolTakeRepository boolTakeRepository;
 
-    @MockBean
-    LoginController loginController;
-    @MockBean
-    KakaoService kakaoService;
-
     private User user;
     private Product product;
     private List<Time> timeList;
@@ -60,7 +55,12 @@ class BoolTakeServiceTest {
 
     @BeforeEach
     public void setUp() {
-        user = new User(123L, "bzun", "email_bzun", "1111");
+        user = User.builder()
+                .kakaoUserId(123L)
+                .name("bzun")
+                .email("email_bzun")
+                .phoneNumber("01012341234")
+                .build();
         userRepository.save(user);
 
         Product product = Product.builder()

--- a/src/test/java/hibuy/server/service/UserProductServiceTest.java
+++ b/src/test/java/hibuy/server/service/UserProductServiceTest.java
@@ -35,9 +35,6 @@ class UserProductServiceTest {
     @Autowired UserProductRepository userProductRepository;
     @Autowired BoolTakeRepository boolTakeRepository;
 
-    @MockBean LoginController loginController;
-    @MockBean KakaoService kakaoService;
-
     private User user;
     private Product product;
     private List<Time> timeList;
@@ -46,7 +43,12 @@ class UserProductServiceTest {
 
     @BeforeEach
     public void setUp() {
-        user = new User(123L,"bzun", "email_bzun", "1111");
+        user = User.builder()
+                .kakaoUserId(123L)
+                .name("bzun")
+                .email("email_bzun")
+                .phoneNumber("1111")
+                .build();
         userRepository.save(user);
         product = Product.builder()
                 .companyName("company")


### PR DESCRIPTION
## 📝Issue: 환경 변수 주입 방식 변경
#50 

## 📝Description
 - 기존에 kakaoService에서 `client_id`와 `client_secret` 환경 변수를 `@Value`를 통해 주입하던 방식에서 `@ConfigurationProperties`를 활용하여 주입하는 방식으로 변경하였습니다.

- JpaAuditingConfig 파일을 따로 분리하였습니다.

## 💣 TroubleShooting 1
- 서비스 레이어 테스트 시 `@Value`를 통한 주입이 이루어지지 않아 Bean 생성에 실패하는 일이 발생하였습니다. 이전에는 이를 `@MockBean` 처리하여 넘어갔지만 모든 서비스 단에서 KakaoService를 Mocking하는 것이 올바르지 않다는 것을 인식하였습니다.
- 위 문제를 해결하기 위해 `@Value`에서 `@ConfigurationProperties`로 환경 변수 주입 방식을 변경하였습니다.
- PropertiesConfiguration 클래스에 `@EnableConfigurationProperties`을 이용해서 생성할 Properties 클래스의 클래스 타입을 명시해주면 Spring Bean으로 등록되기 때문에 정상적으로 Bean이 생성 되는 것을 확인할 수 있었습니다.

## 💣 TroubleShooting 2
- 컨트롤러 레이어 테스트 시 아래와 같은 에러가 발생하였습니다.
```
JPA metamodel must not be empty!
```

원인: `@WebMvcTest`는 JPA 생성과 관련된 기능이 전혀 존재하지 않는 테스트 어노테이션입니다. JPA Auditing 기능을 사용할때 `@SpringBootApplication`에 `@EnableJpaAuditing`을 추가하여 사용하고 있기 때문에 발생합니다.

따라서 `@EnableJPaAuditing`을 JpaAuditingConfig에 붙여 따로 분리하였습니다.

## 📝ETC
- User 빌더 패턴 적용
- DailyTakeRepository 잘못된 메서드 네이밍 수정
- UserRepository의 findByKakaoUserId() 쿼리 메서드 방식으로 변경